### PR TITLE
Use trim instead of replace

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,7 +22,7 @@ document.body.appendChild(function() {
         var userURL = messageContent.children("a.message_sender").attr("href");
         if (userURL != null) {
           var user = userURL.split("/")[2];
-          var message = messageContent.children("span.message_body").text().replace(/\s+/g, "");
+          var message = messageContent.children("span.message_body").text().trim();
           container.prepend($("<a></a>", {
             "class": "ts_icon_reply " + buttonClass,
             "data-action": "reply",


### PR DESCRIPTION
``` js
.replace(/\s+/g, "")
```

Using this will replace all spaces on the message. I think its better to use trim for that.
If you think this PR is unnecessary, you can just close this :sweat_smile:

![slack](https://cloud.githubusercontent.com/assets/2919310/13064917/235f5110-d492-11e5-94b8-f17548b33884.png)
