### PR TITLE
Fix/newline ignored

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Slack 返信引用ボタン(Slack Reply and Quote Button)",
   "short_name": "Slack 返信引用ボタン",
   "description": "Slack に返信と引用ボタンをつけます。Add a reply(mention) and quotation button to Slack.",
-  "version" : "1.10",
+  "version" : "1.11",
   "icons": {
     "16": "img/icon16.png",
     "48": "img/icon48.png",

--- a/script.js
+++ b/script.js
@@ -29,17 +29,21 @@ document.body.appendChild(function() {
         }
       },
 
+      normalizeNewline: function(text) {
+        return '<p>' + text.replace(/\n/g, '</p><p>') + '</p>';
+      },
+
       appendMessageInputText: function(text) {
-        var messageInputText = $("#msg_input div p:last-child")
-        messageInputText.html(messageInputText.html() + text);
+        var messageInputText = $("#msg_input div")
+        messageInputText.append(replyAndQuoteButton.normalizeNewline(text));
 
         var node = document.querySelector('#msg_input > .ql-editor');
         node.focus();
       },
 
       prependMessageInputText: function(text) {
-        var messageInputText = $("#msg_input div p:first-child")
-        messageInputText.html(text + messageInputText.html());
+        var messageInputText = $("#msg_input div")
+        messageInputText.prepend(replyAndQuoteButton.normalizeNewline(text));
 
         // キャレットを末尾に移動させる(by nyamadandan)
         var node = document.querySelector('#msg_input > .ql-editor');
@@ -132,7 +136,7 @@ document.body.appendChild(function() {
     $(document).on("click", "[data-action='quote']", function(event) {
       var permalink = $(event.target).data("permalink");
       var selectedText = replyAndQuoteButton.selectedText;
-      replyAndQuoteButton.appendMessageInputText("\n" + (selectedText !== "" ? replyAndQuoteButton.quoteText(selectedText) : permalink));
+      replyAndQuoteButton.appendMessageInputText(selectedText !== "" ? replyAndQuoteButton.quoteText(selectedText) : permalink);
     });
 
     $(document).on("mousedown", "[data-action='reply2']", function(event) {
@@ -145,12 +149,12 @@ document.body.appendChild(function() {
       var permalink = $(event.target).data("permalink");
       var messageText = $(event.target).data("message");
       var selectedText = replyAndQuoteButton.selectedText;
-      replyAndQuoteButton.prependMessageInputText("@" + user + ":\n" +  replyAndQuoteButton.getQuotedText(messageText, selectedText, permalink) + "\n");
+      replyAndQuoteButton.prependMessageInputText("@" + user + ":\n" +  replyAndQuoteButton.getQuotedText(messageText, selectedText, permalink));
     });
 
     $(document).on("click", "[data-action='mention']", function(event) {
       var user = $(event.target).data("user");
-      replyAndQuoteButton.prependMessageInputText("@" + user + ":\n");
+      replyAndQuoteButton.prependMessageInputText("@" + user + ":");
     });
   };
 


### PR DESCRIPTION
以下の問題に対応

> MacのChromeで返信ボタン使うとリンクのすぐ後ろにカーソルが入ってしまいます。
> 以前は改行されていたと思うのですがなぜなんでしょう？若干使いにくいので修正いただけると助かります。

http://gam0022.net/works/slack-reply-and-quote-button/#comment-3387596259

1行ごとに`<p></p>`を生成することで対応。